### PR TITLE
Fix server startup sequence

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,8 +4,6 @@ const express = require('express');
 const connectDB = require('./config/db');
 
 const app = express();
-connectDB();
-
 app.use(express.json());
 
 app.get('/', (req, res) => {
@@ -15,6 +13,13 @@ app.get('/', (req, res) => {
 app.use('/api/test-runs', require('./routes/testRunRoutes'));
 
 const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+
+// Start server only after a successful DB connection
+const startServer = async () => {
+  await connectDB();
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+};
+
+startServer();


### PR DESCRIPTION
## Summary
- only start Express after MongoDB connection succeeds

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails without MONGODB_URI)*

------
https://chatgpt.com/codex/tasks/task_e_6855c78cb484832bacc63138386c18b4