### PR TITLE
Add Jest and Supertest setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",
-    "dev": "nodemon src/app.js"
+    "dev": "nodemon src/app.js",
+    "test": "jest"
   },
   "dependencies": {
     "dotenv": "^16.5.0",
@@ -13,6 +14,8 @@
     "mongoose": "^8.0.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.0"
+    "jest": "^30.0.2",
+    "nodemon": "^3.0.0",
+    "supertest": "^7.1.1"
   }
 }

--- a/tests/testRunRoutes.test.js
+++ b/tests/testRunRoutes.test.js
@@ -1,0 +1,23 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/models/testRun', () => ({
+  find: jest.fn(() => ({
+    sort: jest.fn().mockResolvedValue([])
+  }))
+}));
+
+const testRunRoutes = require('../src/routes/testRunRoutes');
+const TestRun = require('../src/models/testRun');
+
+const app = express();
+app.use(express.json());
+app.use('/api/test-runs', testRunRoutes);
+
+describe('GET /api/test-runs', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/api/test-runs');
+    expect(res.status).toBe(200);
+    expect(TestRun.find).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- enable Jest testing in `package.json`
- install dev dependencies jest and supertest
- test GET /api/test-runs with Supertest

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855caadd500832b8269d88737d4c456