### PR TITLE
Fix startup sequence

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,11 +15,9 @@ app.use('/api/test-runs', require('./routes/testRunRoutes'));
 const PORT = process.env.PORT || 5000;
 
 // Start server only after a successful DB connection
-const startServer = async () => {
+(async () => {
   await connectDB();
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);
   });
-};
-
-startServer();
+})();


### PR DESCRIPTION
## Summary
- start server with an async IIFE after connecting to MongoDB

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855caac26c0832bac547a34c2080e9f