### PR TITLE
Fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About Me Backend
 
-This backend is designed to store Playwright test runs history.
+This backend is designed to store Playwright test run history.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- fix a phrase describing the storage of test runs

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855caab1f7c832b88cafd5a59e0bc29